### PR TITLE
Feature/autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Note that this component uses Angular 2's [animation system](https://angular.io/
 | animate | boolean | `true` | Whether the sidebar should animate when opening/closing. |
 | defaultStyles | boolean | `false` | Applies some basic default styles to the sidebar. |
 | trapFocus | boolean | `true` | Keeps focus within the sidebar if it's open. |
-| autoFocus | boolean | `true` | Automaticaly focus the first focusable element |
+| autoFocus | boolean | `true` | Automatically focus the first focusable element |
 | sidebarClass | string | | Additional class name on the sidebar element. |
 | overlayClass | string | | Additional class name on the overlay element. |
 | ariaLabel | string | | String used for the sidebar's `aria-label` attribute. |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Note that this component uses Angular 2's [animation system](https://angular.io/
 | animate | boolean | `true` | Whether the sidebar should animate when opening/closing. |
 | defaultStyles | boolean | `false` | Applies some basic default styles to the sidebar. |
 | trapFocus | boolean | `true` | Keeps focus within the sidebar if it's open. |
+| autoFocus | boolean | `true` | Automaticaly focus the first focusable element |
 | sidebarClass | string | | Additional class name on the sidebar element. |
 | overlayClass | string | | Additional class name on the overlay element. |
 | ariaLabel | string | | String used for the sidebar's `aria-label` attribute. |

--- a/demo/src/demo/demo.component.ts
+++ b/demo/src/demo/demo.component.ts
@@ -12,6 +12,7 @@ import { SIDEBAR_POSITION } from 'ng2-sidebar';
       [showOverlay]="_showOverlay"
       [animate]="_animate"
       [trapFocus]="_trapFocus"
+      [autoFocus]="_autoFocus"
       [sidebarClass]="'demo-sidebar'"
       [ariaLabel]="'My sidebar'"
       (onOpen)="_onOpen()"
@@ -19,7 +20,7 @@ import { SIDEBAR_POSITION } from 'ng2-sidebar';
       (onAnimationStarted)="_onAnimationStarted($event)"
       (onAnimationDone)="_onAnimationDone($event)">
       <p>Sidebar contents</p>
-
+      
       <button class="demo-control" (click)="_toggleSidebar()">Close sidebar</button>
       <p><a closeSidebar>This will close the sidebar too</a></p>
     </ng2-sidebar>
@@ -38,6 +39,7 @@ import { SIDEBAR_POSITION } from 'ng2-sidebar';
       <button class="demo-control" (click)="_toggleShowOverlay()">Toggle showOverlay ({{_showOverlay}})</button>
       <button class="demo-control" (click)="_toggleAnimate()">Toggle animate ({{_animate}})</button>
       <button class="demo-control" (click)="_toggleTrapFocus()">Toggle trapFocus ({{_trapFocus}})</button>
+      <button class="demo-control" (click)="_toggleAutoFocus()">Toggle autoFocus ({{_autoFocus}})</button>
 
 
       <h1>Download</h1>
@@ -65,6 +67,7 @@ export class DemoComponent {
   private _showOverlay: boolean = false;
   private _animate: boolean = true;
   private _trapFocus: boolean = true;
+  private _autoFocus: boolean = true;
 
   private _POSITIONS = [SIDEBAR_POSITION.Left, SIDEBAR_POSITION.Right, SIDEBAR_POSITION.Top, SIDEBAR_POSITION.Bottom];
 
@@ -94,6 +97,10 @@ export class DemoComponent {
 
   private _toggleTrapFocus() {
     this._trapFocus = !this._trapFocus;
+  }
+
+   private _toggleAutoFocus() {
+    this._autoFocus = !this._autoFocus;
   }
 
   private _onOpen() {

--- a/src/sidebar.component.ts
+++ b/src/sidebar.component.ts
@@ -139,6 +139,7 @@ export class Sidebar implements AfterContentInit, OnChanges, OnDestroy {
 
   @Input() ariaLabel: string;
   @Input() trapFocus: boolean = true;
+  @Input() autoFocus: boolean = true;
 
   @Output() onOpen: EventEmitter<null> = new EventEmitter<null>();
   @Output() onClose: EventEmitter<null> = new EventEmitter<null>();
@@ -264,7 +265,7 @@ export class Sidebar implements AfterContentInit, OnChanges, OnDestroy {
   // ==============================================================================================
 
   private _setFocusToFirstItem() {
-    if (this._focusableElements && this._focusableElements.length) {
+    if (this.autoFocus && this._focusableElements && this._focusableElements.length) {
       this._focusableElements[0].focus();
     }
   }


### PR DESCRIPTION
Setting autoFocus input to "false" prevents the focusable elements to autofocus when the sidebar is open. This input is "true" by default, so it won't conflict with the current behavior of the component.